### PR TITLE
Change kir /ky/ plural settings to same as for English

### DIFF
--- a/locales/locales.php
+++ b/locales/locales.php
@@ -1600,8 +1600,6 @@ class GP_Locales {
 		$kir->country_code = 'kg';
 		$kir->wp_locale = 'kir';
 		$kir->slug = 'kir';
-		$kir->nplurals = 1;
-		$kir->plural_expression = '0';
 		$kir->google_code = 'ky';
 		$kir->alphabet = 'cyrillic';
 

--- a/tests/phpunit/testcases/test_locales.php
+++ b/tests/phpunit/testcases/test_locales.php
@@ -39,6 +39,10 @@ class GP_Test_Locales extends GP_UnitTestCase {
 		// Expected: 0
 		'id',
 
+		// Actual: 0
+		// Expected: n != 1
+		'uz',
+		
 		// Actual: n != 1
 		// Expected: 0
 		'tir',

--- a/tests/phpunit/testcases/test_locales.php
+++ b/tests/phpunit/testcases/test_locales.php
@@ -42,7 +42,6 @@ class GP_Test_Locales extends GP_UnitTestCase {
 		// Actual: 0
 		// Expected: n != 1
 		'uz',
-		
 		// Actual: n != 1
 		// Expected: 0
 		'tir',

--- a/tests/phpunit/testcases/test_locales.php
+++ b/tests/phpunit/testcases/test_locales.php
@@ -39,10 +39,6 @@ class GP_Test_Locales extends GP_UnitTestCase {
 		// Expected: 0
 		'id',
 
-		// Actual: 0
-		// Expected: n != 1
-		'kir', 'uz',
-
 		// Actual: n != 1
 		// Expected: 0
 		'tir',

--- a/tests/phpunit/testcases/test_locales.php
+++ b/tests/phpunit/testcases/test_locales.php
@@ -42,6 +42,7 @@ class GP_Test_Locales extends GP_UnitTestCase {
 		// Actual: 0
 		// Expected: n != 1
 		'uz',
+
 		// Actual: n != 1
 		// Expected: 0
 		'tir',


### PR DESCRIPTION
Fixes #1633
(GlotPress currently uses incorrect plural parameters for kir/ky)
